### PR TITLE
ci: dependabot for the two ecosystems this repository has

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+# Dependency updates, opened as pull requests so every bump goes through
+# the same gates as any other change.
+#
+# Two ecosystems, because those are the two this repository has: npm is
+# absent by construction (the zerojs gate holds that), so listing it
+# would only produce a manifest-not-found error every week.
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+    groups:
+      actions:
+        patterns: ["*"]
+
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "deps"
+    groups:
+      patch-and-minor:
+        update-types: ["patch", "minor"]


### PR DESCRIPTION
为 GitHub Actions 与 Cargo 两个生态配置 dependabot。npm 不在其列——仓库没有 package.json，`zerojs` 门保证了这一点，列出它只会每周产生一次清单找不到的错误。

两个生态都用 `groups` 合并，一周每个生态一个 PR 而非每个依赖一个。cargo 侧只分组 patch 与 minor，major 单独开 PR 以便单独审查。

改动触及 `.github/`，提交按 guard 门的要求带了 `Verdict:` trailer。

**一个需要你定夺的问题**：dependabot 生成的提交信息形如 `deps: bump serde from 1.0.1 to 1.0.2`，与 `docs/CONTRIBUTING.md:96` 规定的 `card-<stage>.<index>:` 格式不一致，而它无法知道 card 编号。是接受这一类例外、合并前手动改写、还是在 CONTRIBUTING 中写明例外？

## 验证到什么程度

本机未安装 `cargo-public-api`（`docs/CONTRIBUTING.md` 第 7 节将其列为按需安装，本改动不触及任何公开接口），`cargo xtask gates` 因此在 `apisync` 处返回内部失败，其后各门的结果未被打印。我改为单独执行确认 guard：